### PR TITLE
Configure master and slave credentials

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,17 @@ import subprocess
 import io
 import traceback
 
-from flask import Flask, render_template, request, send_file, flash, redirect, url_for, jsonify
+from flask import (
+    Flask,
+    render_template,
+    request,
+    send_file,
+    flash,
+    redirect,
+    url_for,
+    jsonify,
+    session,
+)
 from docxtpl import DocxTemplate
 
 # ------------------------------------------------------------
@@ -17,6 +27,14 @@ from docxtpl import DocxTemplate
 app = Flask(__name__)
 # Inserisci qui la tua chiave segreta generata, ad es. con os.urandom o uuid
 app.secret_key = 'f97b1e6c3a4f4d1e8b7c2a8e0d3abb12'
+
+# Semplice archivio di credenziali (username: {password, role})
+# "master" ha accesso completo, gli utenti "slave" vedono solo alcune info
+USERS = {
+    "master": {"password": "masterpass", "role": "master"},
+    "slave1": {"password": "slavepass1", "role": "slave"},
+    "slave2": {"password": "slavepass2", "role": "slave"},
+}
 
 BASE_DIR        = os.path.abspath(os.path.dirname(__file__))
 TEMPLATES_DOCX  = os.path.join(BASE_DIR, "templates_docx")
@@ -34,7 +52,38 @@ os.makedirs(OUT_DIR, exist_ok=True)
 # ------------------------------------------------------------
 @app.route("/", methods=["GET"])
 def index():
-    return render_template("form.html")
+    if "username" not in session:
+        return redirect(url_for("login"))
+    return render_template(
+        "form.html",
+        username=session.get("username"),
+        role=session.get("role"),
+    )
+
+# ------------------------------------------------------------
+# ROUTE LOGIN
+# ------------------------------------------------------------
+@app.route("/login", methods=["GET", "POST"])
+def login():
+    if request.method == "POST":
+        username = request.form.get("username", "").strip()
+        password = request.form.get("password", "").strip()
+        user = USERS.get(username)
+        if user and user["password"] == password:
+            session["username"] = username
+            session["role"] = user["role"]
+            return redirect(url_for("index"))
+        flash("Credenziali non valide", "error")
+    return render_template("login.html")
+
+
+# ------------------------------------------------------------
+# ROUTE LOGOUT
+# ------------------------------------------------------------
+@app.route("/logout")
+def logout():
+    session.clear()
+    return redirect(url_for("login"))
 
 # ------------------------------------------------------------
 # ROUTE OPZIONALE: pulizia cartella out

--- a/templates/form.html
+++ b/templates/form.html
@@ -26,6 +26,7 @@
 <body>
   <div class="container">
     <h1>Genera Preventivo Fotovoltaico</h1>
+    <p>Utente: {{ username }} - <a href="{{ url_for('logout') }}">Logout</a></p>
 
     <!-- FORM PRINCIPALE -->
     <form id="preventivo-form" onsubmit="return false;">
@@ -119,7 +120,7 @@
         <span class="result-value" id="display-tipologia-cliente">-</span>
       </div>
       <hr>
-      <div class="result-item">
+      <div class="result-item admin-only">
         <span class="result-label">Costo Complessivo:</span>
         <span class="result-value" id="costo-complessivo">-</span>
       </div>
@@ -131,7 +132,7 @@
         <span class="result-label">Provvigione (€):</span>
         <span class="result-value" id="provvigione-val">-</span>
       </div>
-      <div class="result-item">
+      <div class="result-item admin-only">
         <span class="result-label">Margine (€):</span>
         <span class="result-value" id="margine-val">-</span>
       </div>
@@ -161,6 +162,7 @@
   <!-- ====== SCRIPT JAVASCRIPT ==== -->
   <!-- ============================= -->
   <script>
+    const userRole = "{{ role }}";
     // --- DATI PER IL CALCOLO DEI COSTI ---
     const costData = {
       pannelli: {
@@ -213,6 +215,12 @@
     const scontoEl           = document.getElementById('sconto');
     const applicaScontoBtn   = document.getElementById('applicaScontoBtn');
     const generaPdfBtn       = document.getElementById('generaPdfBtn');
+    const adminOnlyEls       = document.querySelectorAll('.admin-only');
+
+    // Solo l'utente "master" vede i campi riservati
+    if (userRole !== 'master') {
+      adminOnlyEls.forEach(el => el.classList.add('hidden'));
+    }
 
     // Span dove mostriamo i risultati
     const displayPotenza           = document.getElementById('display-potenza');

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Login</title>
+  <style>
+    body { font-family: Arial, sans-serif; background: #f5f5f5; color: #333; padding: 20px; }
+    .container { max-width: 400px; margin: 0 auto; background: white; border-radius: 8px; padding: 20px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); }
+    h1 { text-align: center; margin-bottom: 20px; color: #2c7873; }
+    label { display: block; margin-top: 15px; font-weight: bold; }
+    input { width: 100%; padding: 8px; margin-top: 5px; border: 1px solid #ccc; border-radius: 4px; font-size: 1rem; }
+    button { margin-top: 20px; width: 100%; padding: 12px; background: #2c7873; color: white; border: none; border-radius: 4px; font-size: 1rem; cursor: pointer; }
+    button:hover { background: #235d59; }
+    .msg { color: red; text-align: center; margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Login</h1>
+    <form method="POST">
+      <label for="username">Username</label>
+      <input type="text" id="username" name="username" required />
+      <label for="password">Password</label>
+      <input type="password" id="password" name="password" required />
+      <button type="submit">Accedi</button>
+    </form>
+    {% with messages = get_flashed_messages(category_filter=['error']) %}
+      {% if messages %}
+        <div class="msg">{{ messages[0] }}</div>
+      {% endif %}
+    {% endwith %}
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- define master and slave user accounts
- show only cost and margin to master users
- update JS to hide admin-only fields when role is not master

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6842bd5fd2a08321a90755636e6384b6