### PR TITLE
Fix default orientation, map zoom and button size

### DIFF
--- a/templates/analisi.html
+++ b/templates/analisi.html
@@ -34,9 +34,9 @@
     <label for="lon">Longitudine</label>
     <input type="number" step="0.0001" id="lon" placeholder="es. 7.68" />
     <label for="azimuth">Orientamento impianto (0° Sud, 90° Ovest, -90° Est)</label>
-    <input type="number" step="1" id="azimuth" />
+    <input type="number" step="1" id="azimuth" value="0" />
     <label for="tilt">Inclinazione impianto (gradi)</label>
-    <input type="number" step="1" id="tilt" />
+    <input type="number" step="1" id="tilt" value="10" />
     <button id="analizza-btn">Analizza</button>
 
     <table id="result-table" class="hidden">
@@ -87,6 +87,7 @@ function initMap(){
     const place = autocomplete.getPlace();
     if(!place.geometry || !place.geometry.location) return;
     map.panTo(place.geometry.location);
+    map.setZoom(18);
     marker.setPosition(place.geometry.location);
     updateLatLon(place.geometry.location);
   });

--- a/templates/form.html
+++ b/templates/form.html
@@ -24,6 +24,7 @@
       text-align: center;
       border-radius: 4px;
       text-decoration: none;
+      font-size: 1rem;
     }
     .btn-secondary:hover { background: #cf7b2d; text-decoration: none; }
     .results, .discount-section { margin-top: 25px; padding: 15px; background: #f8f9fa; border-radius: 6px; border-left: 4px solid #ff9a3c; }


### PR DESCRIPTION
## Summary
- make orientation and tilt defaults in `analisi.html`
- zoom the map to the searched address
- ensure the secondary button shares the same font size

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684abf4904808321ad3876e641d1a449