### PR TITLE
Implement analysis PDF/DOC generation

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,6 +61,7 @@ TPL_SENZA_ACCUMULO_WALLBOX = os.path.join(
 TPL_CON_ACCUMULO_WALLBOX = os.path.join(
     TEMPLATES_DOCX, "template_con_accumulo_wallbox.docx"
 )
+TPL_ANALISI = os.path.join(TEMPLATES_DOCX, "template_analisi.docx")
 
 # Crea la cartella OUT se non esiste
 os.makedirs(OUT_DIR, exist_ok=True)
@@ -507,6 +508,163 @@ def api_analisi():
     except Exception as e:
         traceback.print_exc()
         return jsonify({"error": str(e)}), 500
+
+
+# ------------------------------------------------------------
+# GENERA DOCUMENTI PER ANALISI ENERGETICA
+# ------------------------------------------------------------
+
+@app.route("/genera_doc_analisi", methods=["POST"])
+def genera_doc_analisi():
+    try:
+        dati = request.get_json(force=True)
+
+        uid = uuid.uuid4().hex[:8]
+        base_name = f"temp_{dati['nome']}_{dati['cognome']}_{uid}"
+        nome_docx_out = base_name + ".docx"
+        path_docx_out = os.path.join(OUT_DIR, nome_docx_out)
+
+        kw = float(dati.get("potenza", 0) or 0)
+        monthly = dati.get("monthly", [])
+        monthly_u = dati.get("monthly_u", [])
+        img_b64 = dati.get("grafico", "")
+        img_data = base64.b64decode(img_b64.split(",", 1)[1]) if "," in img_b64 else base64.b64decode(img_b64)
+
+        doc = DocxTemplate(TPL_ANALISI)
+        from docxtpl import InlineImage
+        from docx.shared import Mm
+        contesto = {
+            "Nome": dati.get("nome", ""),
+            "Cognome": dati.get("cognome", ""),
+            "Pot": f"{kw}",
+            "Incl": str(dati.get("incl", "")),
+            "Orient": str(dati.get("orient", "")),
+            "Grafico": InlineImage(doc, io.BytesIO(img_data), width=Mm(120)),
+        }
+
+        days = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+        for i in range(12):
+            val = monthly[i] if i < len(monthly) else 0
+            contesto[f"Prod_{i+1:02d}"] = f"{val:.2f}"
+            u_val = (
+                monthly_u[i]
+                if i < len(monthly_u)
+                else (val / (days[i] * kw) if kw else 0)
+            )
+            contesto[f"Prod_{i+1:02d}_u"] = f"{u_val:.2f}"
+
+        total = dati.get("total")
+        if total is None:
+            total = sum(monthly)
+        contesto["Prod_tot"] = f"{float(total):.2f}"
+
+        doc.render(contesto)
+        doc.save(path_docx_out)
+
+        with open(path_docx_out, "rb") as f:
+            docx_bytes = f.read()
+
+        try:
+            os.remove(path_docx_out)
+        except Exception:
+            pass
+
+        download_name = f"Analisi_{dati['nome']}_{dati['cognome']}_{uid}.docx"
+        return send_file(
+            io.BytesIO(docx_bytes),
+            as_attachment=True,
+            download_name=download_name,
+            mimetype="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        )
+
+    except Exception as e:
+        traceback.print_exc()
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+
+@app.route("/genera_pdf_analisi", methods=["POST"])
+def genera_pdf_analisi():
+    try:
+        dati = request.get_json(force=True)
+
+        uid = uuid.uuid4().hex[:8]
+        base_name = f"temp_{dati['nome']}_{dati['cognome']}_{uid}"
+        nome_docx_out = base_name + ".docx"
+        path_docx_out = os.path.join(OUT_DIR, nome_docx_out)
+
+        kw = float(dati.get("potenza", 0) or 0)
+        monthly = dati.get("monthly", [])
+        monthly_u = dati.get("monthly_u", [])
+        img_b64 = dati.get("grafico", "")
+        img_data = base64.b64decode(img_b64.split(",", 1)[1]) if "," in img_b64 else base64.b64decode(img_b64)
+
+        doc = DocxTemplate(TPL_ANALISI)
+        from docxtpl import InlineImage
+        from docx.shared import Mm
+        contesto = {
+            "Nome": dati.get("nome", ""),
+            "Cognome": dati.get("cognome", ""),
+            "Pot": f"{kw}",
+            "Incl": str(dati.get("incl", "")),
+            "Orient": str(dati.get("orient", "")),
+            "Grafico": InlineImage(doc, io.BytesIO(img_data), width=Mm(120)),
+        }
+        days = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+        for i in range(12):
+            val = monthly[i] if i < len(monthly) else 0
+            contesto[f"Prod_{i+1:02d}"] = f"{val:.2f}"
+            u_val = (
+                monthly_u[i]
+                if i < len(monthly_u)
+                else (val / (days[i] * kw) if kw else 0)
+            )
+            contesto[f"Prod_{i+1:02d}_u"] = f"{u_val:.2f}"
+        total = dati.get("total")
+        if total is None:
+            total = sum(monthly)
+        contesto["Prod_tot"] = f"{float(total):.2f}"
+
+        doc.render(contesto)
+        doc.save(path_docx_out)
+
+        cmd = [
+            "libreoffice",
+            "--headless",
+            "--convert-to",
+            "pdf",
+            "--outdir",
+            OUT_DIR,
+            path_docx_out,
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr)
+
+        pdf_generated = base_name + ".pdf"
+        path_pdf_generated = os.path.join(OUT_DIR, pdf_generated)
+        with open(path_pdf_generated, "rb") as f:
+            pdf_bytes = f.read()
+
+        try:
+            os.remove(path_pdf_generated)
+        except Exception:
+            pass
+        try:
+            os.remove(path_docx_out)
+        except Exception:
+            pass
+
+        download_name = f"Analisi_{dati['nome']}_{dati['cognome']}_{uid}.pdf"
+        return send_file(
+            io.BytesIO(pdf_bytes),
+            as_attachment=True,
+            download_name=download_name,
+            mimetype="application/pdf",
+        )
+
+    except Exception as e:
+        traceback.print_exc()
+        return jsonify({"status": "error", "message": str(e)}), 500
 
 
 

--- a/templates/analisi.html
+++ b/templates/analisi.html
@@ -25,6 +25,10 @@
   <div class="container" data-kw="{{ kw }}">
     <h1>Analisi Energetica</h1>
     <button type="button" onclick="history.back()">Torna al Preventivo</button>
+    <label for="nome">Nome</label>
+    <input type="text" id="nome" placeholder="Mario" />
+    <label for="cognome">Cognome</label>
+    <input type="text" id="cognome" placeholder="Rossi" />
     <p>Potenza Impianto: <strong id="kw-val"></strong> kW</p>
     <label for="address">Indirizzo</label>
     <input type="text" id="address" placeholder="Inserisci indirizzo" />
@@ -49,6 +53,8 @@
       </tfoot>
     </table>
     <canvas id="chart" width="600" height="300" class="hidden"></canvas>
+    <button id="generaPdfAnalisiBtn" class="hidden">Genera Analisi PDF</button>
+    <button id="generaDocAnalisiBtn" class="hidden">Genera Analisi DOC</button>
   </div>
 
 <script>
@@ -60,6 +66,10 @@ let chart = new Chart(document.getElementById('chart'), {
   data: { labels: mesi, datasets: [{ label: 'kWh', backgroundColor:'#ff9a3c', data: [] }] },
   options: { scales:{ y:{ beginAtZero:true } } }
 });
+
+const generaPdfAnalisiBtn = document.getElementById('generaPdfAnalisiBtn');
+const generaDocAnalisiBtn = document.getElementById('generaDocAnalisiBtn');
+let lastMonthly = [];
 
 let map, marker, autocomplete;
 
@@ -129,6 +139,74 @@ document.getElementById('analizza-btn').addEventListener('click', () => {
     chart.update();
     show(document.getElementById('result-table'));
     show(document.getElementById('chart'));
+    lastMonthly = data.monthly;
+    show(generaPdfAnalisiBtn);
+    show(generaDocAnalisiBtn);
+  })
+  .catch(err => alert(err));
+});
+
+function preparaPayload() {
+  const nome = document.getElementById('nome').value.trim();
+  const cognome = document.getElementById('cognome').value.trim();
+  const orient = parseFloat(document.getElementById('azimuth').value);
+  const incl = parseFloat(document.getElementById('tilt').value);
+  if (!nome || !cognome) {
+    alert('Inserisci nome e cognome');
+    return null;
+  }
+  if (lastMonthly.length !== 12) {
+    alert('Esegui prima l\'analisi');
+    return null;
+  }
+  const days = [31,28,31,30,31,30,31,31,30,31,30,31];
+  const monthly_u = lastMonthly.map((v,i)=> v/(days[i]*kw));
+  return {
+    nome,
+    cognome,
+    potenza: kw,
+    orient,
+    incl,
+    monthly: lastMonthly,
+    monthly_u,
+    grafico: chart.toBase64Image()
+  };
+}
+
+generaPdfAnalisiBtn.addEventListener('click', () => {
+  const payload = preparaPayload();
+  if(!payload) return;
+  fetch('/genera_pdf_analisi', {
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body: JSON.stringify(payload)
+  })
+  .then(r => { if(!r.ok) throw new Error('Errore server'); return r.blob(); })
+  .then(b => {
+    const url = window.URL.createObjectURL(b);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `Analisi_${payload.nome}_${payload.cognome}.pdf`;
+    document.body.appendChild(a); a.click(); a.remove();
+  })
+  .catch(err => alert(err));
+});
+
+generaDocAnalisiBtn.addEventListener('click', () => {
+  const payload = preparaPayload();
+  if(!payload) return;
+  fetch('/genera_doc_analisi', {
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body: JSON.stringify(payload)
+  })
+  .then(r => { if(!r.ok) throw new Error('Errore server'); return r.blob(); })
+  .then(b => {
+    const url = window.URL.createObjectURL(b);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `Analisi_${payload.nome}_${payload.cognome}.docx`;
+    document.body.appendChild(a); a.click(); a.remove();
   })
   .catch(err => alert(err));
 });


### PR DESCRIPTION
## Summary
- enable generation of analysis PDF and DOC files
- add name/surname inputs and buttons on analysis page
- create backend endpoints to build analysis documents from template

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684ac5d4194483219831d64a17c7d061